### PR TITLE
add more #if guards

### DIFF
--- a/Adapters/Editor/LTCGI_ProTvAdapterAutoSetup.cs
+++ b/Adapters/Editor/LTCGI_ProTvAdapterAutoSetup.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+#if UNITY_EDITOR && UDONSHARP
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;

--- a/Adapters/Editor/LTCGI_USharpVideoAdapterAutoSetup.cs
+++ b/Adapters/Editor/LTCGI_USharpVideoAdapterAutoSetup.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+#if UNITY_EDITOR && UDONSHARP
 using System.Linq;
 using UnityEditor;
 using UnityEngine;

--- a/Adapters/LTCGI_ProTvAdapter.cs
+++ b/Adapters/LTCGI_ProTvAdapter.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿#if UDONSHARP
+using UdonSharp;
 using UnityEngine;
 using ArchiTech;
 
@@ -74,3 +75,4 @@ public class LTCGI_ProTvAdapter : UdonSharpBehaviour
         }
     }
 }
+#endif

--- a/Adapters/LTCGI_USharpVideoAdapter.cs
+++ b/Adapters/LTCGI_USharpVideoAdapter.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿#if UDONSHARP
+using UdonSharp;
 using UdonSharp.Video;
 using UnityEngine;
 
@@ -59,3 +60,4 @@ public class LTCGI_USharpVideoAdapter : UdonSharpBehaviour
         }
     }
 }
+#endif

--- a/Lookup Tables/ltc.inc.meta
+++ b/Lookup Tables/ltc.inc.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: d8aa5a4384a112f47924ccc33ad0fd81
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Scripts/Editor/LTCGI_Controller.cs
+++ b/Scripts/Editor/LTCGI_Controller.cs
@@ -10,7 +10,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEditor.SceneManagement;
 
-#if VRC_SDK_VRCSDK3
+#if UDONSHARP
 using UdonSharp;
 using UdonSharpEditor;
 #endif
@@ -562,7 +562,7 @@ namespace pi.LTCGI
 
             if (!fast && this != null && this.gameObject != null)
             {
-                #if VRC_SDK_VRCSDK3
+                #if UDONSHARP
                 LTCGI_UdonAdapter adapter;
                 #pragma warning disable 618
                 LTCGI_UdonAdapter[] adapters = this.gameObject.GetUdonSharpComponents<LTCGI_UdonAdapter>();
@@ -574,7 +574,7 @@ namespace pi.LTCGI
 
                 if (adapters == null || adapters.Length == 0)
                 {
-                    #if VRC_SDK_VRCSDK3
+                    #if UDONSHARP
                     adapter = this.gameObject.AddUdonSharpComponent<LTCGI_UdonAdapter>();
                     #else
                     adapter = this.gameObject.AddComponent<LTCGI_RuntimeAdapter>();
@@ -582,7 +582,7 @@ namespace pi.LTCGI
                 }
                 else
                 {
-                    #if VRC_SDK_VRCSDK3
+                    #if UDONSHARP
                     adapter = (LTCGI_UdonAdapter)adapters[0];
                     #else
                     adapter = (LTCGI_RuntimeAdapter)adapters[0];

--- a/Scripts/Editor/LTCGI_ControllerExternal.cs
+++ b/Scripts/Editor/LTCGI_ControllerExternal.cs
@@ -7,7 +7,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEditor.Build.Reporting;
-#if VRC_SDK_VRCSDK2 || VRC_SDK_VRCSDK3
+#if VRC_SDK_VRCSDK2 || UDONSHARP
 using VRC.SDKBase.Editor.BuildPipeline;
 #endif
 #endif
@@ -401,7 +401,7 @@ AudioLink: {(LTCGI_Controller.AudioLinkAvailable ? "Available" : "Not Detected")
         }
     }
 
-    #if VRC_SDK_VRCSDK3
+    #if UDONSHARP
     public class VRCSDKHookLTCGI : IVRCSDKBuildRequestedCallback
     {
         public int callbackOrder => 68;

--- a/Scripts/LTCGI_ExampleToggle.cs
+++ b/Scripts/LTCGI_ExampleToggle.cs
@@ -1,4 +1,4 @@
-﻿#if VRC_SDK_VRCSDK3
+﻿#if UDONSHARP
 using UdonSharp;
 
 // NOTE: This script has to be in the "_LTCGI/Scripts" folder, *or* reference

--- a/Scripts/LTCGI_UdonAdapter.cs
+++ b/Scripts/LTCGI_UdonAdapter.cs
@@ -488,7 +488,7 @@ public class LTCGI_RuntimeAdapter : MonoBehaviour
     }
 
     // extremely cursed compat stuff
-    #if ! UDONSHARP
+    #if !UDONSHARP
     public void UpdateProxy() {}
     public void ApplyProxyModifications() {}
     #endif

--- a/Scripts/LTCGI_UdonAdapter.cs
+++ b/Scripts/LTCGI_UdonAdapter.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using UnityEngine;
 
-#if VRC_SDK_VRCSDK3
+#if UDONSHARP
 using UdonSharp;
 using VRC.SDKBase;
 using VRC.Udon;
 #endif
 
-#if VRC_SDK_VRCSDK3
+#if UDONSHARP
 [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
 public class LTCGI_UdonAdapter : UdonSharpBehaviour
 #else
@@ -488,7 +488,7 @@ public class LTCGI_RuntimeAdapter : MonoBehaviour
     }
 
     // extremely cursed compat stuff
-    #if !VRC_SDK_VRCSDK3
+    #if ! UDONSHARP
     public void UpdateProxy() {}
     public void ApplyProxyModifications() {}
     #endif


### PR DESCRIPTION
this allows the ltcgi repo to be cloned and used into standalone, avatar and udonsharp (and even world projects without udonsharp theoretically) without throwing compiler errors