### PR TITLE
Bug fix on `bakeInProgress` and `LTCGI_BakeReset` not being saved if scene is "clean"

### DIFF
--- a/Scripts/Editor/LTCGI_ControllerBake.cs
+++ b/Scripts/Editor/LTCGI_ControllerBake.cs
@@ -198,6 +198,7 @@ namespace pi.LTCGI
             }
 
             bakeInProgress = true;
+            EditorSceneManager.MarkSceneDirty(gameObject.scene);
             EditorSceneManager.SaveOpenScenes();
             EditorUtility.ClearProgressBar();
 


### PR DESCRIPTION
Hi, I have found a bug in LTCGI that will cause issue when baking shadow map.

According to the logic, the plugin will first disables/changes some GameObjects that don't want to affects the shadow map, and adds a `LTCGI_BakeReset` component to temporary store its original state, and turn the `bakeInProgress` flag to true, then calls `EditorSceneManager.SaveOpenScenes()` before start to bake. But the later method has no effects if the scene is consider "clean" (which can be achieved by manually save the scene before trigger bake shadowmap), even the logic has changes the scene programmatically before.

This pull request contains the fix on this issue by adding a line before that call.

P.S. I have another unrelated patch that add support to use Bakery's Light Mesh to bake the shadow map instead of emissive material, which seems brings a cleaner result. If you want it I can open another pull request on this.