### PR TITLE
Feature: Add support for Bakery LightMesh for Shadowmap baking

### DIFF
--- a/Scripts/Editor/LTCGI_BakeReset.cs
+++ b/Scripts/Editor/LTCGI_BakeReset.cs
@@ -18,6 +18,10 @@ namespace pi.LTCGI
         public StaticEditorFlags Flags;
         public ShadowCastingMode ShadowCastingMode;
 
+        public bool ResetLightMesh;
+        public Color lightMeshColor;
+        public float lightMeshIntensity;
+
         public bool RemoveBakeryLightMesh;
 
         internal void ApplyReset()
@@ -35,6 +39,15 @@ namespace pi.LTCGI
             }
 
             #if BAKERY_INCLUDED
+            if (ResetLightMesh)
+            {
+                var lm = this.GetComponent<BakeryLightMesh>();
+                if (lm != null)
+                {
+                    lm.color = lightMeshColor;
+                    lm.intensity = lightMeshIntensity;
+                }
+            }
             if (RemoveBakeryLightMesh)
             {
                 var lm = this.GetComponent<BakeryLightMesh>();


### PR DESCRIPTION
Hello! I'm here again for a new feature that brings support for Bakery LightMesh for Shadowmap baking.

Besides the original emissive material approach, now it can use in combination with Bakery's LightMesh. To use this new approach, it only requires to add the component along side with the LTCGI's screen or emitter component like this:
![image](https://user-images.githubusercontent.com/4715281/213749430-b34e61d7-f242-4b3d-a3c6-29b2edb4af1c.png)

When it is baking shadow map and detects LightMesh component added, it will automatically adjusts the color and intensity to match the configuration instead of assigning an emissive material, and it will rollback to its original settings when it is done.

I only tested with Bakery and VRCSDK installed, I think it won't cause any issues when use with other environments.