### PR TITLE
Force enable renderer when baking ltcgi screen

### DIFF
--- a/Scripts/Editor/LTCGI_BakeReset.cs
+++ b/Scripts/Editor/LTCGI_BakeReset.cs
@@ -17,6 +17,7 @@ namespace pi.LTCGI
         public Material[] Materials;
         public StaticEditorFlags Flags;
         public ShadowCastingMode ShadowCastingMode;
+        public bool RendererEnabled;
 
         public bool RemoveBakeryLightMesh;
 
@@ -32,6 +33,7 @@ namespace pi.LTCGI
                 rend.sharedMaterials = Materials;
                 rend.shadowCastingMode = ShadowCastingMode;
                 GameObjectUtility.SetStaticEditorFlags(this.gameObject, Flags);
+                rend.enabled = RendererEnabled;
             }
 
             #if BAKERY_INCLUDED

--- a/Scripts/Editor/LTCGI_ControllerBake.cs
+++ b/Scripts/Editor/LTCGI_ControllerBake.cs
@@ -174,11 +174,13 @@ namespace pi.LTCGI
                     r.Materials = rend.sharedMaterials;
                     r.Flags = flags;
                     r.ShadowCastingMode = rend.shadowCastingMode;
+                    r.RendererEnabled = rend.enabled;
                     if (rend.shadowCastingMode == ShadowCastingMode.Off || rend.shadowCastingMode == ShadowCastingMode.ShadowsOnly)
                     {
                         rend.shadowCastingMode = ShadowCastingMode.On;
                     }
                     rend.sharedMaterials = new Material[] { mat };
+                    rend.enabled = true;
                     GameObjectUtility.SetStaticEditorFlags(rend.gameObject, flags | StaticEditorFlags.ContributeGI);
                 };
 


### PR DESCRIPTION
I have an enabled ltcgi screen but it has its mesh renderer disabled; therefore, when trying to bake a shadowmap, it won't be able to emit it's r/g/b light. This pr adds `RendererEnabled` to the bake reset script and makes sure to turn the mesh renderer on when baking.

I've been trying to get this feature to work for the last week until I realized this was the issue today. The only other problem I had was that the screen was colliding with another mesh in the scene, but moving it slightly forward makes sure it emits properly.

Thank you so much for making LTCGI, it's wonderful