### PR TITLE
Handle screens without mesh renderers during bake

### DIFF
--- a/Scripts/Editor/LTCGI_ControllerBake.cs
+++ b/Scripts/Editor/LTCGI_ControllerBake.cs
@@ -206,8 +206,15 @@ namespace pi.LTCGI
                 }
                 else
                 {
-                    var rend = scr.gameObject.GetComponent<MeshRenderer>();
-                    handleRenderer(rend);
+                    if (scr.gameObject.TryGetComponent<MeshRenderer>(out MeshRenderer rend))
+                    {
+                        handleRenderer(rend);
+                    }
+                    else
+                    {
+                        /* There is no mesh renderer on this object */
+                        Debug.LogWarning("LTCGI: An object with an LTCGI_Screen component has no mesh renderer, it will not contribute shadows to this bake", scr.gameObject);
+                    }
                 }
             }
 


### PR DESCRIPTION
This commit adds a small level of handling to an object with an LTCGI_Screen and no mesh renderer during a shadowmap bake (without Bakery). The bake proceeds but the screen will not contribute any emissons. The user is warned and pointed to the object that lacks the renderer via the debug logs.

When I was following the docs, I noted that a screen could be mesh render-less for an invisible source. When I tried to bake a shadowmap for a scene that had a screen set up that way, the script seemed to hang with a stuck progress bar, and I had to restart my editor and reset things. 😅

I went and added quick and dirty handling to encountering screens like that during the bake. I was also thinking it might be possible to add a mesh renderer automatically, then remove it after, but I wasn't sure if that behavior was desirable vs. just warning the user (or if I was just not very smart for trying to bake like that in the first place).