### PR TITLE
Add quick fix for duplicate migration folder creation

### DIFF
--- a/Editor/LTCGI_Controller.cs
+++ b/Editor/LTCGI_Controller.cs
@@ -62,6 +62,8 @@ namespace pi.LTCGI
         public bool HasDynamicScreens = false;
         public bool HasCylinders = false;
 
+        private static bool MigrationChecked = false;
+
         public void OnEnable()
         {
             if (PrefabUtility.IsPartOfPrefabAsset(this.gameObject)) return;
@@ -92,43 +94,47 @@ namespace pi.LTCGI
         public static void MigratoryBirdsDontMigrateAsMuchAsWeDoButThisFunctionWillTakeCareOfItNonetheless()
         {
             var hasChanges = false;
-            if (!AssetDatabase.IsValidFolder("Assets\\_pi_"))
+            if (MigrationChecked == false)
             {
-                AssetDatabase.CreateFolder("Assets", "_pi_");
-                hasChanges = true;
-            }
-            if (!AssetDatabase.IsValidFolder("Assets\\_pi_\\_LTCGI"))
-            {
-                AssetDatabase.CreateFolder("Assets\\_pi_", "_LTCGI");
-                hasChanges = true;
-            }
-            if (!AssetDatabase.IsValidFolder("Assets\\_pi_\\_LTCGI\\Shaders"))
-            {
-                AssetDatabase.CreateFolder("Assets\\_pi_\\_LTCGI", "Shaders");
-                hasChanges = true;
-            }
-            if (!File.Exists("Assets\\_pi_\\_LTCGI\\Shaders\\LTCGI.cginc"))
-            {
-                File.WriteAllText("Assets\\_pi_\\_LTCGI\\Shaders\\LTCGI.cginc", "#include \"Packages\\at.pimaker.ltcgi\\Shaders\\LTCGI.cginc\"");
-                hasChanges = true;
-            }
+                if (!AssetDatabase.IsValidFolder("Assets\\_pi_"))
+                {
+                    AssetDatabase.CreateFolder("Assets", "_pi_");
+                    hasChanges = true;
+                }
+                if (!AssetDatabase.IsValidFolder("Assets\\_pi_\\_LTCGI"))
+                {
+                    AssetDatabase.CreateFolder("Assets\\_pi_", "_LTCGI");
+                    hasChanges = true;
+                }
+                if (!AssetDatabase.IsValidFolder("Assets\\_pi_\\_LTCGI\\Shaders"))
+                {
+                    AssetDatabase.CreateFolder("Assets\\_pi_\\_LTCGI", "Shaders");
+                    hasChanges = true;
+                }
+                if (!File.Exists("Assets\\_pi_\\_LTCGI\\Shaders\\LTCGI.cginc"))
+                {
+                    File.WriteAllText("Assets\\_pi_\\_LTCGI\\Shaders\\LTCGI.cginc", "#include \"Packages\\at.pimaker.ltcgi\\Shaders\\LTCGI.cginc\"");
+                    hasChanges = true;
+                }
 
-            // god I hate this part, Unity dumb dumb
-            if (!AssetDatabase.IsValidFolder("Assets\\Gizmos"))
-            {
-                AssetDatabase.CreateFolder("Assets", "Gizmos");
-                hasChanges = true;
-            }
-            if (!File.Exists("Assets\\Gizmos\\LTCGI_Screen_Gizmo.png"))
-            {
-                File.Copy("Packages\\at.pimaker.ltcgi\\LTCGI_Screen_Gizmo.png", "Assets\\Gizmos\\LTCGI_Screen_Gizmo.png", true);
-                hasChanges = true;
-            }
+                // god I hate this part, Unity dumb dumb
+                if (!AssetDatabase.IsValidFolder("Assets\\Gizmos"))
+                {
+                    AssetDatabase.CreateFolder("Assets", "Gizmos");
+                    hasChanges = true;
+                }
+                if (!File.Exists("Assets\\Gizmos\\LTCGI_Screen_Gizmo.png"))
+                {
+                    File.Copy("Packages\\at.pimaker.ltcgi\\LTCGI_Screen_Gizmo.png", "Assets\\Gizmos\\LTCGI_Screen_Gizmo.png", true);
+                    hasChanges = true;
+                }
 
-            if (hasChanges)
-            {
-                Debug.Log("LTCGI Migration took place, refreshing asset database");
-                AssetDatabase.Refresh();
+                if (hasChanges)
+                {
+                    Debug.Log("LTCGI Migration took place");
+                }
+
+                MigrationChecked = true;
             }
         }
 


### PR DESCRIPTION
This is a hack fix for a small, arcane issue that I don't know the exact root cause of, but the symptom was that when I deleted my manually installed version of LTCGI tonight and migrated to the package install via github url, the scripts created a handful of empty, duplicate folders in my `Assets` directory.

Steps to recreate bug:
1. Create empty Unity project
2. Install LTCGI package from git url
3. Add LTCGI Controller to scene
4. Delete LTCGI package and its `Assets/` folders but leave scene as-is, then reinstall package

The function `MigratoryBirdsDontMigrateAsMuchAsWeDoButThisFunctionWillTakeCareOfItNonetheless` (lol) is running multiple times and at least one subsequent invocation of the function beyond the first doesn't have its `AssetDatabase.IsValidFolder` calls return `true`, despite the folders existing.

I don't know why. It may have something to do with the nature of the asset database: the result of the folder creation may not be available via the API until some later point, depending on _when_ the API is used? (This is beyond my level of Unity expertise. I was led to that hypothesis after reading the "Asset Import Order" part of [this doc](https://docs.unity3d.com/2023.3/Documentation/Manual/AssetDatabaseCustomizingWorkflow.html).)

So I made sure those folders are only checked once per whatever interval Unity resets static variables. I also removed the manual database refresh because I _think_ if you're just using the `AssetDatabase` API you don't need to manually refresh.

If you know an actual not hack fix or just want to close this as a won't-fix, it's no big deal, but I figured I'd open it anyway!