### PR TITLE
use cross-platform paths for migration

### DIFF
--- a/Editor/LTCGI_Controller.cs
+++ b/Editor/LTCGI_Controller.cs
@@ -92,36 +92,20 @@ namespace pi.LTCGI
         public static void MigratoryBirdsDontMigrateAsMuchAsWeDoButThisFunctionWillTakeCareOfItNonetheless()
         {
             var hasChanges = false;
-            if (!AssetDatabase.IsValidFolder("Assets\\_pi_"))
+            var cgincPath = Path.Combine("Assets", "_pi_", "_LTCGI", "Shaders", "LTCGI.cginc");
+            if (!File.Exists(cgincPath))
             {
-                AssetDatabase.CreateFolder("Assets", "_pi_");
-                hasChanges = true;
-            }
-            if (!AssetDatabase.IsValidFolder("Assets\\_pi_\\_LTCGI"))
-            {
-                AssetDatabase.CreateFolder("Assets\\_pi_", "_LTCGI");
-                hasChanges = true;
-            }
-            if (!AssetDatabase.IsValidFolder("Assets\\_pi_\\_LTCGI\\Shaders"))
-            {
-                AssetDatabase.CreateFolder("Assets\\_pi_\\_LTCGI", "Shaders");
-                hasChanges = true;
-            }
-            if (!File.Exists("Assets\\_pi_\\_LTCGI\\Shaders\\LTCGI.cginc"))
-            {
-                File.WriteAllText("Assets\\_pi_\\_LTCGI\\Shaders\\LTCGI.cginc", "#include \"Packages\\at.pimaker.ltcgi\\Shaders\\LTCGI.cginc\"");
+                var contents = "#include \"" + Path.Combine("Packages", "at.pimaker.ltcgi", "Shaders", "LTCGI.cginc") + "\"";
+                Directory.CreateDirectory(Path.GetDirectoryName(cgincPath));
+                File.WriteAllText(cgincPath, contents);
                 hasChanges = true;
             }
 
-            // god I hate this part, Unity dumb dumb
-            if (!AssetDatabase.IsValidFolder("Assets\\Gizmos"))
+            var gizmoPath = Path.Combine("Assets", "Gizmos", "LTCGI_Screen_Gizmo.png"); 
+            if (!File.Exists(gizmoPath))
             {
-                AssetDatabase.CreateFolder("Assets", "Gizmos");
-                hasChanges = true;
-            }
-            if (!File.Exists("Assets\\Gizmos\\LTCGI_Screen_Gizmo.png"))
-            {
-                File.Copy("Packages\\at.pimaker.ltcgi\\LTCGI_Screen_Gizmo.png", "Assets\\Gizmos\\LTCGI_Screen_Gizmo.png", true);
+                Directory.CreateDirectory(Path.GetDirectoryName(gizmoPath));
+                File.Copy(Path.Combine("Packages", "at.pimaker.ltcgi", "LTCGI_Screen_Gizmo.png"), gizmoPath, true);
                 hasChanges = true;
             }
 


### PR DESCRIPTION
## Issue: 

On platforms other than Windows, the migration process creates `LTCGI.cginc` and gizmo files outside of the Assets folder. 

Dependent shaders will error out due to the include path not pointing to a valid file.

```
drwxr-xr-x 10 op op  4096 Dec  9 10:40  ./
drwxr-xr-x 13 op op  4096 Dec  8 19:57  ../
drwxr-xr-x 19 op op  4096 Dec  8 23:11  Assets/
-rw-r--r--  1 op op 11809 Dec  8 20:30 'Assets\Gizmos\LTCGI_Screen_Gizmo.png'
-rw-r--r--  1 op op    56 Dec  8 20:30 'Assets\_pi_\_LTCGI\Shaders\LTCGI.cginc'
-rw-r--r--  1 op op   403 Dec  8 20:03  Avatars22.sln
drwxr-xr-x 15 op op  4096 Dec  9 10:41  Library/
drwxr-xr-x  2 op op  4096 Dec  9 10:41  Logs/
drwxr-xr-x  7 op op  4096 Dec  8 22:53  Packages/
drwxr-xr-x  3 op op  4096 Dec  9 10:41  ProjectSettings/
drwxr-xr-x  4 op op  4096 Dec  9 10:45  Temp/
drwxr-xr-x  3 op op  4096 Dec  9 10:38  UserSettings/
```

## Proposed solution
1. Use `Path.Combine` instead of hardcoded path separators
2. Use `Directory.CreateDirectory` to create the folder structure recursively. (Using AssetDatabase is not necessary, as we're not injecting any metadata.)

## Tested
On Linux, but the behavior is expected to be the same on all platforms.