### PR TITLE
Clarify difference between Debug and Standard lightmap bake

### DIFF
--- a/Editor/LTCGI_ControllerExternal.cs
+++ b/Editor/LTCGI_ControllerExternal.cs
@@ -106,11 +106,11 @@ namespace pi.LTCGI
 
             LTCGIDocsHelper.DrawHelpButton("https://ltcgi.dev/Advanced/Shadowmaps", "Shadowmap Baking");
 
-            if (!LTCGI_Controller.Singleton.bakeInProgress && GUILayout.Button("Bake Shadowmap"))
+            if (!LTCGI_Controller.Singleton.bakeInProgress && GUILayout.Button("Bake Debug Shadowmap"))
             {
                 LTCGI_Controller.BakeLightmap();
             }
-            else if (!LTCGI_Controller.Singleton.bakeInProgress && GUILayout.Button("Bake Shadowmap and Normal Lightmap"))
+            else if (!LTCGI_Controller.Singleton.bakeInProgress && GUILayout.Button("Bake LTCGI Shadowmap and Standard Lightmap"))
             {
                 LTCGI_Controller.BakeLightmapFollowup();
             }


### PR DESCRIPTION
Spent hours trying to figure out why the LTCGI bake was showing on the main lightmap,
thought "Bake Shadowmap and Normal lightmap" meant directional lightmap.