### PR TITLE
Explicitly initialize ltcgi_output.color for diffuse and specular

### DIFF
--- a/Shaders/LTCGI.cginc
+++ b/Shaders/LTCGI.cginc
@@ -297,6 +297,7 @@ void LTCGI_Contribution(
                         lmd = smoothstep(0.0, LTCGI_SPECULAR_LIGHTMAP_STEP, saturate(lm - LTCGI_LIGHTMAP_CUTOFF));
                 }
                 ltcgi_output diff;
+                diff.color = 0;
                 LTCGI_Evaluate(input, worldNorm, viewDir, identityBrdf, roughness, true, diff);
                 diff.intensity *= lmd;
 
@@ -316,6 +317,7 @@ void LTCGI_Contribution(
             if (flags.specular)
             {
                 ltcgi_output spec;
+                spec.color = 0;
                 LTCGI_Evaluate(input, worldNorm, viewDir, Minv, roughness, false, spec);
                 spec.intensity *= spec_amp * smoothstep(0.0, LTCGI_SPECULAR_LIGHTMAP_STEP, saturate(lm - LTCGI_LIGHTMAP_CUTOFF));
 


### PR DESCRIPTION
This should mitigate a compiler failure which commonly affects the Mochie Standard shader for some reason.

The repro is difficult and inconsistent, but when it does get triggered, adding these two lines and then reimporting the affected shader (usually mochie standard as mentioned) fixes the issue.