### PR TITLE
Fix incorrect Uniform path on Linux

### DIFF
--- a/Editor/LTCGI_Controller.cs
+++ b/Editor/LTCGI_Controller.cs
@@ -629,6 +629,9 @@ namespace pi.LTCGI
         {
             var curscene = EditorSceneManager.GetActiveScene().name;
             var path = @"Assets\LTCGI-Generated\StaticUniform-" + curscene + ".exr";
+#if UNITY_EDITOR_LINUX
+            path = path.Replace("\\", "/");
+#endif
 
             if (staticUniformTemp == null)
             {


### PR DESCRIPTION
Replace "\\" with "/" in the Uniforms .exr path on Linux that causes the Uniform cache to be stored in the wrong location and failing to load, leading to a incorrect UV from a \<null\> Texture2D.