### PR TITLE
Add support for Unity versions earlier than 2022

### DIFF
--- a/Editor/LTCGI_Controller.cs
+++ b/Editor/LTCGI_Controller.cs
@@ -148,7 +148,11 @@ namespace pi.LTCGI
                 return;
             if (Lightmapping.isRunning)
                 return;
-            if (UnityEngine.SceneManagement.SceneManager.loadedSceneCount == 0)
+            #if UNITY_2022_1_OR_NEWER
+                if (UnityEngine.SceneManagement.SceneManager.loadedSceneCount == 0)
+            #else
+                if (UnityEditor.SceneManagement.EditorSceneManager.loadedSceneCount == 0)
+            #endif
                 return;
 
             #if DEBUG_LOG


### PR DESCRIPTION
This change allows me to use this package on Unity 2021

The unity editor automatically sets `UNITY_2022_1_OR_NEWER` to true

This fix was also mentioned here: https://github.com/PiMaker/ltcgi/issues/30#issuecomment-2081749258