### PR TITLE
Don't break iOS build target

### DIFF
--- a/Runtime/LTCGI_Assembly.asmdef
+++ b/Runtime/LTCGI_Assembly.asmdef
@@ -8,6 +8,7 @@
     "includePlatforms": [
         "Android",
         "Editor",
+        "iOS",
         "LinuxStandalone64",
         "WebGL",
         "WindowsStandalone64"


### PR DESCRIPTION
iOS needs to be included as a platform, otherwise having your project set to iOS will cause the project to not build all it's sources correctly and prevents uploading, even if you don't have ltcgi enabled in your scene. While this is not meant to give iOS support for ltcgi, which would probably need some further tweaks thanks to metal, this is important to not break projects that have multiple platform targets and only use one project.