### PR TITLE
Feature: Add an option to force-update the materials regardless of the editor’s state

### DIFF
--- a/Editor/LTCGI_Controller.cs
+++ b/Editor/LTCGI_Controller.cs
@@ -141,19 +141,22 @@ namespace pi.LTCGI
         [MenuItem("Tools/LTCGI/Force Material Update")]
         public static void UpdateMaterialsMenu() => Singleton?.UpdateMaterials();
         public void UpdateMaterials() => UpdateMaterials(false);
-        public void UpdateMaterials(bool fast, LTCGI_Screen screen = null)
+        public void UpdateMaterials(bool fast, LTCGI_Screen screen = null, bool force = false)
         {
-            // don't mess with Udon emulation
-            if (EditorApplication.isPlaying)
-                return;
-            if (Lightmapping.isRunning)
-                return;
-            #if UNITY_2022_1_OR_NEWER
-                if (UnityEngine.SceneManagement.SceneManager.loadedSceneCount == 0)
-            #else
-                if (UnityEditor.SceneManagement.EditorSceneManager.loadedSceneCount == 0)
-            #endif
-                return;
+            if (!force)
+            {
+                // don't mess with Udon emulation
+                if (EditorApplication.isPlaying)
+                    return;
+                if (Lightmapping.isRunning)
+                    return;
+                #if UNITY_2022_1_OR_NEWER
+                    if (UnityEngine.SceneManagement.SceneManager.loadedSceneCount == 0)
+                #else
+                    if (UnityEditor.SceneManagement.EditorSceneManager.loadedSceneCount == 0)
+                #endif
+                    return;
+            }
 
             #if DEBUG_LOG
             Debug.Log($"LTCGI: beginning update ({(fast ? "fast" : "full")})");


### PR DESCRIPTION
Add an option to the `UpdateMaterials` method so that materials can be forcibly updated from an external context, regardless of the editor’s state. This is helpful for implementing automated build pipelines.

For example, if one wants to bake the lightmap of multiple variants of a space under different lighting conditions in VRChat, variants of that space at different locations in the scene need to be created, along with some temporary LTCGI Screen components (See: https://vrclibrary.com/wiki/books/maebbies-precise-solutions/page/how-to-swap-out-baked-lightmaps-for-daynight-mode). 

However, during the build process, it is necessary to (1) assemble those spaces together (applying transforms) and (2) remove the temporary LTCGI Screen components. Both of these steps can be automated by implementing Unity’s `IProcessSceneWithReport` interface. After removing the temporary LTCGI components in the build-time, the screen list in the LTCGI Controller also needs to be updated to prevent any runtime exceptions.

To achieve the second objective of the automated build pipeline, see the following code snippet for reference:

```C#
public class RemoveOnBuildBuildingPipeline : IProcessSceneWithReport
{
    public void OnProcessScene(UnityEngine.SceneManagement.Scene scene, BuildReport report)
    {
        RemoveOnBuild[] removeOnBuilds = Object.FindObjectsOfType<RemoveOnBuild>(true);
        foreach (RemoveOnBuild removeOnBuild in removeOnBuilds)
        {
            Object.DestroyImmediate(removeOnBuild.gameObject);
        }

#if LTCGI_INCLUDED
        // with the new option: force=true
        LTCGI_Controller.Singleton.UpdateMaterials(false, null, true);
#endif
    }
}

```

FYI, this is how my scene looks like in edit-time as an example:

![Screenshot 2025-06-01 174046_a](https://github.com/user-attachments/assets/1b711d4e-b1dc-48bc-8b90-68168d710b2d)
