### PR TITLE
UdonSharp API new Function

### DIFF
--- a/Runtime/LTCGI_UdonAdapter.cs
+++ b/Runtime/LTCGI_UdonAdapter.cs
@@ -248,6 +248,23 @@ public class LTCGI_UdonAdapter : MonoBehaviour
         if (!this.enabled) Update();
     }
 
+    public void _SetALBand(int screen, int band)
+    {
+        if (screen < 0 || band < 0 || band > 3) return;
+
+        uint flags = getFlags(screen);
+
+        // Clear flags
+        flags &= ~(0b11u << 13);
+
+        // Set new flags
+        flags |= ((uint)band & 0b11u) << 13;
+
+        setFlags(screen, flags);
+
+        if (!this.enabled) Update();
+    }
+
     public void _SetVideoTexture(Texture texture)
     {
         BlurCRTInput.material.SetTexture("_MainTex", texture);


### PR DESCRIPTION
### Summary

This PR introduces a new public method `_SetALBand(int screen, int band)` to the `LTCGI_UdonAdapter` class. It allows dynamically changing the AudioLink band index used per light/screen at runtime.

### Changes

- Added `_SetALBand` method using existing `getFlags` / `setFlags` helpers.
- Safely modifies bits 13–14 of the flags float to set AudioLink band (0–3).
- Fully compatible with the current packed flag system.

### Notes
Previously, the AudioLink band was fixed per light and could not be changed at runtime. This addition improves flexibility and allows more dynamic, music-reactive lighting setups in VRChat worlds.

My final goal is to create a VDJ table to make effects at runtime in world
